### PR TITLE
Improvements for CE lightmapping

### DIFF
--- a/Launcher/Credits.xaml.cs
+++ b/Launcher/Credits.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System.Windows;
-using ToolkitLauncher.Properties;
 
 namespace ToolkitLauncher
 {

--- a/Launcher/FilePicker.cs
+++ b/Launcher/FilePicker.cs
@@ -2,7 +2,6 @@
 using System;
 using System.IO;
 using System.Windows.Forms;
-using System.Windows.Controls;
 using ToolkitLauncher.ToolkitInterface;
 
 public class FilePicker
@@ -105,7 +104,7 @@ public class FilePicker
 	}
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	/// <param name="path"></param>
 	/// <param name="root"></param>

--- a/Launcher/MainWindow.xaml
+++ b/Launcher/MainWindow.xaml
@@ -16,7 +16,7 @@
         <local:GameGenToIsEnabled x:Key="GameGenToIsEnabled" />
         <local:ModelContentModifier x:Key="ModelContentModifier" />
         <local:TextContentModifier x:Key="TextContentModifier" />
-        <local:LightmapConfigModifier x:Key="LightmapConfigModifier" />        
+        <local:LightmapConfigModifier x:Key="LightmapConfigModifier" />
         <local:PRTContentModifier x:Key="PRTContentModifier" />
         <local:PhantomVisibility x:Key="PhantomVisibility" />
         <local:PackageResourceVisibility x:Key="PackageResourceVisibility" />
@@ -133,10 +133,26 @@
                                                         <RowDefinition Height="*"/>
                                                         <RowDefinition Height="Auto"/>
                                                     </Grid.RowDefinitions>
-                                                    <StackPanel Grid.Row="0" HorizontalAlignment="Stretch" VerticalAlignment="Top" >
-                                                        <Slider x:Name="light_quality_slider" Foreground="Black" IsSnapToTickEnabled="True" Ticks="0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1" TickPlacement="BottomRight" AutoToolTipPlacement="BottomRight" AutoToolTipPrecision="1" Minimum="0.1" Maximum="1" Value="1" Visibility="{Binding SelectedIndex, Converter={StaticResource DropdownSelectionToVisibilityConverter}, ConverterParameter=0, ElementName=toolkit_selection}"/>
-                                                    </StackPanel>
-                                                    <ToggleButton Grid.Row="2" x:Name ="radiosity_quality" Content ="{Binding IsChecked, Converter={StaticResource RadiosityContentModifier}, ConverterParameter=0, ElementName=radiosity_quality}" Visibility="{Binding SelectedIndex, Converter={StaticResource DropdownSelectionToVisibilityConverter}, ConverterParameter=0, ElementName=toolkit_selection}" HorizontalAlignment="Center" Padding="4" MinWidth="75" MinHeight="26" MaxHeight="26" VerticalAlignment="Bottom"/>
+                                                    <Grid Grid.Row="0" Visibility="{Binding SelectedIndex, Converter={StaticResource DropdownSelectionToVisibilityConverter}, ConverterParameter=0, ElementName=toolkit_selection}">
+                                                        <Grid.RowDefinitions>
+                                                            <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="Auto"/>
+                                                            <RowDefinition Height="8"/>
+                                                            <RowDefinition Height="Auto"/>
+                                                        </Grid.RowDefinitions>
+                                                        <Grid Grid.Row="0">
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                            </Grid.ColumnDefinitions>
+                                                            <Label Grid.Column="0" x:Name="low_quality" HorizontalAlignment="Left">Low</Label>
+                                                            <Label Grid.Column="1" x:Name="max_quality" HorizontalAlignment="Right">Max</Label>
+                                                        </Grid>
+                                                        <StackPanel Grid.Row="1" HorizontalAlignment="Stretch" VerticalAlignment="Top" >
+                                                            <Slider x:Name="light_quality_slider" Foreground="Black" IsDirectionReversed="True" IsSnapToTickEnabled="True" Ticks="0.000001, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.999999" TickPlacement="BottomRight" AutoToolTipPlacement="BottomRight" AutoToolTipPrecision="1" Minimum="0.000001" Maximum="0.999999" Value="0.999999"/>
+                                                        </StackPanel>
+                                                        <ToggleButton Grid.Row="3" x:Name="radiosity_quality" Content ="{Binding IsChecked, Converter={StaticResource RadiosityContentModifier}, ConverterParameter=0, ElementName=radiosity_quality}" HorizontalAlignment="Center" Padding="4" MinWidth="75" MinHeight="26" MaxHeight="26" VerticalAlignment="Bottom"/>
+                                                    </Grid>
                                                     <Grid Grid.Row="1">
                                                         <Grid.ColumnDefinitions>
                                                             <ColumnDefinition Width="5"/>
@@ -302,7 +318,7 @@
                                                     <ComboBoxItem Content="Sprites"/>
                                                     <ComboBoxItem Content="Interface"/>
                                                 </ComboBox>
-                                            </GroupBox>                                            
+                                            </GroupBox>
                                             <Button Grid.Row="3" Content="Compile Bitmap" Click="CompileImage" VerticalAlignment="Bottom" IsEnabled="{Binding Text.Length, ElementName=compile_image_path, Mode=OneWay}"/>
                                         </Grid>
                                     </Grid>
@@ -326,7 +342,7 @@
                                                 <RowDefinition Height="Auto"/>
                                                 <RowDefinition Height="8"/>
                                                 <RowDefinition Height="Auto"/>
-                                                <RowDefinition Height="Auto"/>                                                
+                                                <RowDefinition Height="Auto"/>
                                                 <RowDefinition/>
                                             </Grid.RowDefinitions>
                                             <Grid>
@@ -348,7 +364,7 @@
                                             <Grid Grid.Row="2">
                                                 <Grid.RowDefinitions>
                                                     <RowDefinition Height="Auto"/>
-                                                    <RowDefinition Height="8"/>                                                    
+                                                    <RowDefinition Height="8"/>
                                                     <RowDefinition Height="Auto"/>
                                                 </Grid.RowDefinitions>
                                                 <Grid.ColumnDefinitions>
@@ -599,10 +615,10 @@
             <Grid Background="Black" Opacity="0.5"/>
             <Border
             MinWidth="250"
-            Background="#FFE5E5E5" 
-            BorderBrush="Black" 
-            BorderThickness="1" 
-            HorizontalAlignment="Center" 
+            Background="#FFE5E5E5"
+            BorderBrush="Black"
+            BorderThickness="1"
+            HorizontalAlignment="Center"
             VerticalAlignment="Center" RenderTransformOrigin="0.508,-0.635" Margin="138,42,153,291" Height="80">
                 <StackPanel>
                     <TextBlock Margin="5" Text="Run Custom Command" FontWeight="Bold" FontFamily="Cambria" HorizontalAlignment="Center" VerticalAlignment="Center" RenderTransformOrigin="0.351,0.429" />
@@ -632,9 +648,9 @@
                         <Grid Grid.Column="1" Grid.Row="1">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="8"/>                                
+                                <RowDefinition Height="8"/>
                                 <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="8"/>                                
+                                <RowDefinition Height="8"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <GroupBox Grid.Row="0" x:Name="lightmap_flags" Header="Lightmap Flags">
@@ -699,6 +715,6 @@
                     </Grid>
                 </StackPanel>
             </Border>
-        </Grid>             
+        </Grid>
     </Grid>
 </Window>

--- a/Launcher/PathSettings.xaml
+++ b/Launcher/PathSettings.xaml
@@ -4,8 +4,8 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:ToolkitLauncher.ToolkitInterface"
-        xmlns:toolkit_local="clr-namespace:ToolkitLauncher"        
-        xmlns:sys="clr-namespace:System;assembly=mscorlib"        
+        xmlns:toolkit_local="clr-namespace:ToolkitLauncher"
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
         mc:Ignorable="d"
         Title="Paths" SizeToContent="WidthAndHeight" MinHeight="460" MinWidth="370">
     <Window.Resources>
@@ -19,7 +19,7 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="5"/>
-            <RowDefinition Height="Auto"/>            
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="5"/>
         </Grid.RowDefinitions>
@@ -36,7 +36,7 @@
                 <ColumnDefinition Width="8"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="8"/>
-                <ColumnDefinition Width="Auto"/>                
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <ComboBox Grid.Column="0" x:Name="profile_select" SelectionChanged="profile_selection_SelectionChanged" SelectedIndex="0" HorizontalAlignment="Left" VerticalAlignment="Stretch" Padding="4" MinWidth="128" MaxWidth="128" MinHeight="26"/>
             <Button Grid.Column="2" x:Name="add_button" Content="Add" HorizontalAlignment="Left" MinHeight="26" Width="63" Click="add_button_Click"/>
@@ -47,13 +47,13 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="8"/>
-                <RowDefinition Height="Auto"/>                    
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="8"/>
                 <RowDefinition Height="*"/>
                 <RowDefinition Height="8"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="8"/>
-                <RowDefinition Height="Auto"/>                    
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <Label Grid.Row="0" x:Name="first_launch" HorizontalAlignment="Center">Select the toolkit applications to continue.</Label>
             <GroupBox Grid.Row="2" x:Name="profile_name_box" Header="Profile Name" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" IsEnabled="False">
@@ -112,7 +112,7 @@
                             </Grid>
                             <TextBox Grid.Column="2" Grid.Row="2" Name="sapien_path" BorderBrush="{StaticResource brushWatermarkBorder}" VerticalAlignment="Center" Background="Transparent" Height="26" TextChanged="profile_dataChangedEventHandler"/>
                         </Grid>
-                    </GroupBox>                    
+                    </GroupBox>
                     <GroupBox Grid.Column="2" Grid.Row="4" x:Name="guerilla_path_box" Header="Guerilla Path" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                         <Grid>
                             <Grid.ColumnDefinitions>
@@ -130,7 +130,7 @@
                             </Grid>
                             <TextBox Grid.Column="2" Grid.Row="4" Name="guerilla_path" BorderBrush="{StaticResource brushWatermarkBorder}" VerticalAlignment="Center" Background="Transparent" Height="26" TextChanged="profile_dataChangedEventHandler"/>
                         </Grid>
-                    </GroupBox>                     
+                    </GroupBox>
                 </Grid>
             </GroupBox>
             <Grid Grid.Row="6">
@@ -144,7 +144,6 @@
                         <ComboBox x:Name="gen_type" SelectedIndex="0" HorizontalAlignment="Center" VerticalAlignment="Center" MinWidth="75" MinHeight="26" SelectionChanged="profile_data_SelectionChanged">
                             <ComboBoxItem Content="Gen 1"/>
                             <ComboBoxItem Content="Gen 2"/>
-                            <ComboBoxItem Content="Gen 3"/>
                         </ComboBox>
                     </Grid>
                 </GroupBox>
@@ -259,6 +258,6 @@
                     </StackPanel>
                 </Border>
             </Grid>
-        </Grid>        
+        </Grid>
     </Grid>
 </Window>

--- a/Launcher/PathSettings.xaml.cs
+++ b/Launcher/PathSettings.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
@@ -19,7 +18,7 @@ namespace ToolkitLauncher
         [Description("Standalone")]
         release_standalone,
         [Description("Internal")]
-        release_internal,
+        release_internal
     }
 
     /// <summary>
@@ -55,7 +54,6 @@ namespace ToolkitLauncher
             hek_box.IsEnabled = has_profiles;
             build_type_box.IsEnabled = has_profiles;
             gen_type_box.IsEnabled = has_profiles;
-            community_tools.IsEnabled = has_profiles;
         }
 
         readonly FilePicker.Options toolExeOptions = FilePicker.Options.FileSelect(
@@ -469,7 +467,7 @@ namespace ToolkitLauncher
         }
 
         private static void WriteJSONFile()
-        {   
+        {
             List<ProfileSettingsJSON> JSONSettingsList = new List<ProfileSettingsJSON>();
             JsonSerializerOptions options = new()
             {

--- a/Launcher/ToolkitInterface/H1Toolkit.cs
+++ b/Launcher/ToolkitInterface/H1Toolkit.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 
 namespace ToolkitLauncher.ToolkitInterface

--- a/Launcher/ToolkitInterface/H2Toolkit.cs
+++ b/Launcher/ToolkitInterface/H2Toolkit.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using System;
-using System.IO;
 
 namespace ToolkitLauncher.ToolkitInterface
 {
@@ -16,7 +15,7 @@ namespace ToolkitLauncher.ToolkitInterface
         override public async Task ImportBitmaps(string path, string type)
         {
             string bitmaps_command = "bitmaps";
-            if (MainWindow.halo_2_standalone_community || MainWindow.halo_2_mcc || MainWindow.halo_2_internal )
+            if (MainWindow.halo_2_standalone_community || MainWindow.halo_2_mcc || MainWindow.halo_2_internal)
             {
                 bitmaps_command = "bitmaps-with-type";
                 await RunTool(ToolType.Tool, new List<string>() { bitmaps_command, path, type });
@@ -50,7 +49,7 @@ namespace ToolkitLauncher.ToolkitInterface
         {
             return lightmapArgs.level_combobox.ToString().ToLower();
         }
-    
+
         public override async Task BuildLightmap(string scenario, string bsp, LightmapArgs args)
         {
             string quality = GetLightmapQuality(args);

--- a/Launcher/ToolkitInterface/ToolkitBase.cs
+++ b/Launcher/ToolkitInterface/ToolkitBase.cs
@@ -38,7 +38,7 @@ namespace ToolkitLauncher.ToolkitInterface
         public class MissingFile : ToolkitException
         {
             /// <summary>
-            /// 
+            ///
             /// </summary>
             /// <param name="filename">Path to the file relative to the base directory</param>
             public MissingFile(string filename)
@@ -132,8 +132,8 @@ namespace ToolkitLauncher.ToolkitInterface
         /// <param name="path"></param>
         /// <param name="platform"></param>
         /// <param name="class_type"></param>
-        /// <param name="bitrate"></param> 
-        /// <param name="ltf_path"></param> 
+        /// <param name="bitrate"></param>
+        /// <param name="ltf_path"></param>
         /// <returns></returns>
         public abstract Task ImportSound(string sound_command, string path, string platform, string class_type, string bitrate, string ltf_path);
 
@@ -262,7 +262,7 @@ namespace ToolkitLauncher.ToolkitInterface
                 commnad_line += escape_arg(arg);
             await StartProcessWithShell(executable, commnad_line);
         }
-        
+
         /// <summary>
         /// Run a executable in a cmd.exe shell that pauses after the executable returns
         /// </summary>
@@ -325,7 +325,7 @@ namespace ToolkitLauncher.ToolkitInterface
                     throw;
                 }
             }
-        
+
         }
     }
 }


### PR DESCRIPTION
Reverse order of options in CE slider as 0.000001 is actually the max and 0.999999 is the lowest.

Add labels for order of quality for CE lightmapping

Remove unused directives.

Make get_default_path args easier to understand.

Limit instance count to available logical processors on system.

Add property for checking if a build is a version of Halo 2.

Add a FilePicker.Option for JMS and ASS so that CE and H2 builds can have different descriptions in file dialog.

Remove whitespace throughout the project

Remove some useless settings.

Update some strings.