### PR TITLE
Auto FBX

### DIFF
--- a/Launcher/MainWindow.xaml
+++ b/Launcher/MainWindow.xaml
@@ -273,6 +273,7 @@
                                                             <RowDefinition Height="{Binding SelectedIndex, Converter={StaticResource ToolkitToSpaceConverter}, ConverterParameter=10, ElementName=toolkit_selection}"/>
                                                             <RowDefinition Height="*"/>
                                                             <RowDefinition Height="{Binding SelectedIndex, Converter={StaticResource ToolkitToSpaceConverter}, ConverterParameter=11, ElementName=toolkit_selection}"/>
+                                                            <RowDefinition Height="{Binding SelectedIndex, Converter={StaticResource ToolkitToSpaceConverter}, ConverterParameter=11, ElementName=toolkit_selection}"/>
                                                             <RowDefinition Height="{Binding SelectedIndex, Converter={StaticResource ToolkitToSpaceConverter}, ConverterParameter=13, ElementName=toolkit_selection}"/>
                                                         </Grid.RowDefinitions>
                                                         <Grid Grid.Row="0" Visibility="{Binding SelectedIndex, Converter={StaticResource ProfiletoVisibility}, ConverterParameter=3, ElementName=toolkit_selection}">
@@ -288,11 +289,14 @@
                                                         <Grid Grid.Row="1">
                                                             <CheckBox x:Name="disable_asserts" Content="{Binding SelectedIndex, Converter={StaticResource ProfiletoContent}, ConverterParameter=5, ElementName=toolkit_selection}" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="{DynamicResource TextColor}" ToolTip="{Binding SelectedIndex, Converter={StaticResource ProfiletoContent}, ConverterParameter=3, ElementName=toolkit_selection}"/>
                                                         </Grid>
-                                                        <Grid Grid.Row="2" Visibility="{Binding SelectedIndex, Converter={StaticResource ProfiletoVisibility}, ConverterParameter=12, ElementName=toolkit_selection}">
+                                                        <Grid Grid.Row="2">
+                                                            <CheckBox x:Name="struct_auto_fbx" Content="Auto FBX" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="{DynamicResource TextColor}" ToolTip="Automatically run fbx-to-ass for relevant structure."/>
+                                                        </Grid>
+                                                        <Grid Grid.Row="3" Visibility="{Binding SelectedIndex, Converter={StaticResource ProfiletoVisibility}, ConverterParameter=12, ElementName=toolkit_selection}">
                                                             <CheckBox x:Name="instance_cmd" Content="Instance Output" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="{DynamicResource TextColor}" ToolTip="Keeps the instance output windows open if enabled. Disable if you live on the wild side."/>
                                                         </Grid>
-                                                        <Grid Grid.Row="3" Visibility="{Binding SelectedIndex, Converter={StaticResource ProfiletoVisibility}, ConverterParameter=11, ElementName=toolkit_selection}">
-                                                            <ComboBox x:Name="structure_import_type" Grid.Column="4" MinHeight="26" VerticalAlignment="Center" SelectedIndex="0" ToolTip="Select the command to use for the level.">
+                                                        <Grid Grid.Row="4" Visibility="{Binding SelectedIndex, Converter={StaticResource ProfiletoVisibility}, ConverterParameter=11, ElementName=toolkit_selection}">
+                                                            <ComboBox x:Name="structure_import_type" Grid.Column="5" MinHeight="26" VerticalAlignment="Center" SelectedIndex="0" ToolTip="Select the command to use for the level.">
                                                                 <ComboBoxItem Content="Structure"/>
                                                                 <ComboBoxItem Content="Design"/>
                                                                 <ComboBoxItem Content="Seams"/>
@@ -608,6 +612,7 @@
                                                                 <CheckBox Grid.Row="1" Grid.Column="1" x:Name="verbose_anim" Content="Verbose Animation" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="{DynamicResource TextColor}" ToolTip="Enable to have more verbose output during animation imports"/>
                                                                 <CheckBox Grid.Row="2" Grid.Column="1" x:Name="uncompressed_anim" Content="Uncompressed Animation" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="{DynamicResource TextColor}" ToolTip="Enable to import uncompressed animations"/>
                                                                 <CheckBox Grid.Row="3" Grid.Column="1" x:Name="reset_compression" Content="Reset Compression" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="{DynamicResource TextColor}" ToolTip="Enable to reset compression"/>
+                                                                <CheckBox Grid.Row="3" Grid.Column="0" x:Name="model_auto_fbx" Content="Auto Convert FBX" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="{DynamicResource TextColor}" ToolTip="Automatically convert FBX files to JMS within the relevant data directory."/>
                                                             </Grid>
                                                         </Grid>
                                                     </Grid>

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -703,7 +703,7 @@ namespace ToolkitLauncher
                 bool is_release = true;
                 StructureType structure_command = (StructureType)structure_import_type.SelectedIndex;
 
-                await toolkit.ImportStructure(structure_command, level_path, phantom_fix, is_release, disable_asserts.IsChecked ?? false);
+                await toolkit.ImportStructure(structure_command, level_path, phantom_fix, is_release, disable_asserts.IsChecked ?? false, struct_auto_fbx.IsChecked ?? false);
             }
             if (levelCompileType.HasFlag(level_compile_type.light))
             {
@@ -859,7 +859,7 @@ namespace ToolkitLauncher
 
         private async void compile_model_Click(object sender, RoutedEventArgs e)
         {
-            await toolkit.ImportModel(compile_model_path.Text, model_compile_type, phantom_hack_collision.IsChecked ?? false, h2_lod_logic.IsChecked ?? false, prt_enabled.IsChecked ?? false, fp_anim.IsChecked ?? false, character_fp_path.Text, weapon_fp_path.Text, accurate_render.IsChecked ?? false, verbose_anim.IsChecked ?? false, uncompressed_anim.IsChecked ?? false, sky_model.IsChecked ?? false, reset_compression.IsChecked ?? false);
+            await toolkit.ImportModel(compile_model_path.Text, model_compile_type, phantom_hack_collision.IsChecked ?? false, h2_lod_logic.IsChecked ?? false, prt_enabled.IsChecked ?? false, fp_anim.IsChecked ?? false, character_fp_path.Text, weapon_fp_path.Text, accurate_render.IsChecked ?? false, verbose_anim.IsChecked ?? false, uncompressed_anim.IsChecked ?? false, sky_model.IsChecked ?? false, reset_compression.IsChecked ?? false, model_auto_fbx.IsChecked ?? false);
         }
 
         private async void import_sound_Click(object sender, RoutedEventArgs e)

--- a/Launcher/ToolkitInterface/H1AToolkit.cs
+++ b/Launcher/ToolkitInterface/H1AToolkit.cs
@@ -70,7 +70,7 @@ namespace ToolkitLauncher.ToolkitInterface
         /// <returns></returns>
         public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression, bool autoFBX)
         {
-            if (autoFBX) { await AutoFBX.Model(this, path, importType); }
+            if (autoFBX) { await AutoFBX.Model(this, path, importType, true); }
 
             // todo(num0005): detect when the command is done running even when using -pause (and remove the forced shell usage)
             if (importType.HasFlag(ModelCompile.render))

--- a/Launcher/ToolkitInterface/H1AToolkit.cs
+++ b/Launcher/ToolkitInterface/H1AToolkit.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using ToolkitLauncher.Utility;
 using static ToolkitLauncher.ToolkitProfiles;
 
 namespace ToolkitLauncher.ToolkitInterface
@@ -69,6 +70,8 @@ namespace ToolkitLauncher.ToolkitInterface
         /// <returns></returns>
         public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression, bool autoFBX)
         {
+            if (autoFBX) { await AutoFBX.Model(this, path, importType); }
+
             // todo(num0005): detect when the command is done running even when using -pause (and remove the forced shell usage)
             if (importType.HasFlag(ModelCompile.render))
                 await RunTool(ToolType.Tool, new() { "model", path, h2SelectionLogic.ToString() }, true);
@@ -82,6 +85,8 @@ namespace ToolkitLauncher.ToolkitInterface
 
         public override async Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast, bool autoFBX)
         {
+            if (autoFBX) { await AutoFBX.Structure(this, data_file, true); }
+
             // todo(num0005): detect when the command is done running even when using -pause (and remove the forced shell usage)
             var info = SplitStructureFilename(data_file);
             await RunTool(ToolType.Tool, new () { "structure", info.ScenarioPath, info.BspName, phantom_fix.ToString() }, true);

--- a/Launcher/ToolkitInterface/H1AToolkit.cs
+++ b/Launcher/ToolkitInterface/H1AToolkit.cs
@@ -67,7 +67,7 @@ namespace ToolkitLauncher.ToolkitInterface
         /// <param name="phantomFix"></param>
         /// <param name="h2SelectionLogic"></param>
         /// <returns></returns>
-        public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression)
+        public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression, bool autoFBX)
         {
             // todo(num0005): detect when the command is done running even when using -pause (and remove the forced shell usage)
             if (importType.HasFlag(ModelCompile.render))
@@ -80,7 +80,7 @@ namespace ToolkitLauncher.ToolkitInterface
                 await RunTool(ToolType.Tool, new() { "animations", path }, true);
         }
 
-        public override async Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast)
+        public override async Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast, bool autoFBX)
         {
             // todo(num0005): detect when the command is done running even when using -pause (and remove the forced shell usage)
             var info = SplitStructureFilename(data_file);

--- a/Launcher/ToolkitInterface/H1Toolkit.cs
+++ b/Launcher/ToolkitInterface/H1Toolkit.cs
@@ -11,7 +11,7 @@ namespace ToolkitLauncher.ToolkitInterface
     {
         public H1Toolkit(ProfileSettingsLauncher profile, string baseDirectory, Dictionary<ToolType, string> toolPaths) : base(profile, baseDirectory, toolPaths) { }
 
-        override public async Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast)
+        override public async Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast, bool autoFBX)
         {
             var info = SplitStructureFilename(data_file);
             await RunTool(ToolType.Tool, new() { "structure", info.ScenarioPath, info.BspName });
@@ -56,7 +56,7 @@ namespace ToolkitLauncher.ToolkitInterface
         /// <param name="path"></param>
         /// <param name="importType"></param>
         /// <returns></returns>
-        public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression)
+        public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression, bool autoFBX)
         {
             if (importType.HasFlag(ModelCompile.render))
                 await RunTool(ToolType.Tool, new() { "model", path });

--- a/Launcher/ToolkitInterface/H1Toolkit.cs
+++ b/Launcher/ToolkitInterface/H1Toolkit.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using ToolkitLauncher.Utility;
 using static ToolkitLauncher.ToolkitProfiles;
 
 namespace ToolkitLauncher.ToolkitInterface
@@ -11,8 +12,19 @@ namespace ToolkitLauncher.ToolkitInterface
     {
         public H1Toolkit(ProfileSettingsLauncher profile, string baseDirectory, Dictionary<ToolType, string> toolPaths) : base(profile, baseDirectory, toolPaths) { }
 
+        /* For AutoFBX */
+        public override List<ImportTypeInfo> GetImportTypeInfo()
+        {
+            return new List<ImportTypeInfo>() {
+                new ImportTypeInfo(ModelCompile.render, "models", ""), // Commands are blank because H1 tool doesn't have options for fbx-to-jms
+                new ImportTypeInfo(ModelCompile.physics, "physics", "")
+            };
+        }
+
         override public async Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast, bool autoFBX)
         {
+            if (autoFBX) { await AutoFBX.Structure(this, data_file, true); }
+
             var info = SplitStructureFilename(data_file);
             await RunTool(ToolType.Tool, new() { "structure", info.ScenarioPath, info.BspName });
         }
@@ -58,6 +70,8 @@ namespace ToolkitLauncher.ToolkitInterface
         /// <returns></returns>
         public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression, bool autoFBX)
         {
+            if (autoFBX) { await AutoFBX.Model(this, path, importType); }
+
             if (importType.HasFlag(ModelCompile.render))
                 await RunTool(ToolType.Tool, new() { "model", path });
             if (importType.HasFlag(ModelCompile.collision))

--- a/Launcher/ToolkitInterface/H1Toolkit.cs
+++ b/Launcher/ToolkitInterface/H1Toolkit.cs
@@ -70,7 +70,7 @@ namespace ToolkitLauncher.ToolkitInterface
         /// <returns></returns>
         public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression, bool autoFBX)
         {
-            if (autoFBX) { await AutoFBX.Model(this, path, importType); }
+            if (autoFBX) { await AutoFBX.Model(this, path, importType, true); }
 
             if (importType.HasFlag(ModelCompile.render))
                 await RunTool(ToolType.Tool, new() { "model", path });

--- a/Launcher/ToolkitInterface/H2AToolkit.cs
+++ b/Launcher/ToolkitInterface/H2AToolkit.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using ToolkitLauncher.Utility;
 using static ToolkitLauncher.ToolkitProfiles;
 
 namespace ToolkitLauncher.ToolkitInterface
@@ -66,6 +67,8 @@ namespace ToolkitLauncher.ToolkitInterface
 
         override public async Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast, bool autoFBX)
         {
+            if (autoFBX) { await AutoFBX.Structure(this, data_file, false); }
+
             ToolType tool = useFast ? ToolType.ToolFast : ToolType.Tool;
             bool is_ass_file = data_file.ToLowerInvariant().EndsWith("ass");
             string command = is_ass_file ? "structure-new-from-ass" : "structure-from-jms";
@@ -101,6 +104,8 @@ namespace ToolkitLauncher.ToolkitInterface
             {
                 flags = set_flags(flags, "reset_compression");
             }
+
+            if (autoFBX) { await AutoFBX.Model(this, path, importType); }
 
             if (importType.HasFlag(ModelCompile.render))
                 await RunTool(ToolType.Tool, new() { "render", path, accurateRender.ToString(), renderPRT.ToString() });

--- a/Launcher/ToolkitInterface/H2AToolkit.cs
+++ b/Launcher/ToolkitInterface/H2AToolkit.cs
@@ -105,7 +105,7 @@ namespace ToolkitLauncher.ToolkitInterface
                 flags = set_flags(flags, "reset_compression");
             }
 
-            if (autoFBX) { await AutoFBX.Model(this, path, importType); }
+            if (autoFBX) { await AutoFBX.Model(this, path, importType, false); }
 
             if (importType.HasFlag(ModelCompile.render))
                 await RunTool(ToolType.Tool, new() { "render", path, accurateRender.ToString(), renderPRT.ToString() });

--- a/Launcher/ToolkitInterface/H2AToolkit.cs
+++ b/Launcher/ToolkitInterface/H2AToolkit.cs
@@ -64,7 +64,7 @@ namespace ToolkitLauncher.ToolkitInterface
             await RunTool(ToolType.Tool, new() { "bitmaps", path, type, debug_plate.ToString() });
         }
 
-        override public async Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast)
+        override public async Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast, bool autoFBX)
         {
             ToolType tool = useFast ? ToolType.ToolFast : ToolType.Tool;
             bool is_ass_file = data_file.ToLowerInvariant().EndsWith("ass");
@@ -83,7 +83,7 @@ namespace ToolkitLauncher.ToolkitInterface
             return flag_string;
         }
 
-        public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression)
+        public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression, bool autoFBX)
         {
 #if !DEBUG
             renderPRT = false; // broken right now

--- a/Launcher/ToolkitInterface/H2Toolkit.cs
+++ b/Launcher/ToolkitInterface/H2Toolkit.cs
@@ -202,7 +202,7 @@ namespace ToolkitLauncher.ToolkitInterface
         /// <returns></returns>
         public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression, bool autoFBX)
         {
-            if (autoFBX) { await AutoFBX.Model(this, path, importType); }
+            if (autoFBX) { await AutoFBX.Model(this, path, importType, false); }
 
             if (importType.HasFlag(ModelCompile.render))
                 await RunTool(ToolType.Tool, new() { "model-render", path });

--- a/Launcher/ToolkitInterface/H2Toolkit.cs
+++ b/Launcher/ToolkitInterface/H2Toolkit.cs
@@ -37,7 +37,7 @@ namespace ToolkitLauncher.ToolkitInterface
             await RunTool(ToolType.Tool, new List<string>() { "new-strings", path });
         }
 
-        override public async Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast)
+        override public async Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast, bool autoFBX)
         {
             bool is_ass_file = data_file.ToLowerInvariant().EndsWith("ass");
             string command = is_ass_file ? "structure-new-from-ass" : "structure-from-jms";
@@ -187,7 +187,7 @@ namespace ToolkitLauncher.ToolkitInterface
         /// <param name="path"></param>
         /// <param name="importType"></param>
         /// <returns></returns>
-        public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression)
+        public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression, bool autoFBX)
         {
             if (importType.HasFlag(ModelCompile.render))
                 await RunTool(ToolType.Tool, new() { "model-render", path });

--- a/Launcher/ToolkitInterface/H2Toolkit.cs
+++ b/Launcher/ToolkitInterface/H2Toolkit.cs
@@ -5,6 +5,7 @@ using static ToolkitLauncher.ToolkitProfiles;
 using System.IO;
 using System.Threading;
 using System.Diagnostics;
+using ToolkitLauncher.Utility;
 
 namespace ToolkitLauncher.ToolkitInterface
 {
@@ -16,6 +17,16 @@ namespace ToolkitLauncher.ToolkitInterface
         protected virtual string sapienWindowClass
         {
             get => "Sapien";
+        }
+
+        /* For AutoFBX */
+        public override List<ImportTypeInfo> GetImportTypeInfo()
+        {
+            return new List<ImportTypeInfo>() {
+                new ImportTypeInfo(ModelCompile.render, "render", "render"),
+                new ImportTypeInfo(ModelCompile.collision, "collision", "collision"),
+                new ImportTypeInfo(ModelCompile.physics, "physics", "physics")
+            };
         }
 
         override public async Task ImportBitmaps(string path, string type, bool debug_plate)
@@ -39,6 +50,8 @@ namespace ToolkitLauncher.ToolkitInterface
 
         override public async Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast, bool autoFBX)
         {
+            if (autoFBX) { await AutoFBX.Structure(this, data_file, false); }
+
             bool is_ass_file = data_file.ToLowerInvariant().EndsWith("ass");
             string command = is_ass_file ? "structure-new-from-ass" : "structure-from-jms";
             string use_release = release ? "yes" : "no";
@@ -189,6 +202,8 @@ namespace ToolkitLauncher.ToolkitInterface
         /// <returns></returns>
         public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression, bool autoFBX)
         {
+            if (autoFBX) { await AutoFBX.Model(this, path, importType); }
+
             if (importType.HasFlag(ModelCompile.render))
                 await RunTool(ToolType.Tool, new() { "model-render", path });
             if (importType.HasFlag(ModelCompile.collision))

--- a/Launcher/ToolkitInterface/H3Toolkit.cs
+++ b/Launcher/ToolkitInterface/H3Toolkit.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -32,8 +33,21 @@ namespace ToolkitLauncher.ToolkitInterface
             await RunTool(ToolType.Tool, new() { "strings", path });
         }
 
-        override public async Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast)
+        private async Task StructureAutoFBX(string data_file)
         {
+            /* Convert Structure */
+            string inPath = BaseDirectory + "\\data\\" + data_file.ToLower().Replace(".ass", ".fbx"); // Jank code, should probably make this safer
+            if (File.Exists(inPath))
+            {
+                string outPath = BaseDirectory + "\\data\\" + data_file;
+                await RunTool(ToolType.Tool, new() { "fbx-to-ass", inPath, outPath });
+            }
+        }
+
+        override public async Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast, bool autoFBX)
+        {
+            if(autoFBX) { await StructureAutoFBX(data_file); }
+
             ToolType tool = useFast ? ToolType.ToolFast : ToolType.Tool;
             string tool_command = structure_command.ToString().Replace("_", "-");
             string data_path = data_file;
@@ -174,13 +188,128 @@ namespace ToolkitLauncher.ToolkitInterface
 
         }
 
+        // Some nonsense
+        private class ImportTypeInfo
+        {
+            public ModelCompile importType;
+            public string folderName, commandOption;
+            public ImportTypeInfo(ModelCompile a, string b, string c)
+            {
+                importType = a;
+                folderName = b;
+                commandOption = c;
+            }
+        }
+
+        private static List<ImportTypeInfo> IMPORT_TYPE_INFOS = new List<ImportTypeInfo>()
+        {
+            new ImportTypeInfo(ModelCompile.render, "render", "render"),
+            new ImportTypeInfo(ModelCompile.collision, "collision", "collision"),
+            new ImportTypeInfo(ModelCompile.physics, "physics", "physics-or-all")
+        };
+
+        private async Task ModelAutoFBX(string path, ModelCompile importType)
+        {
+            /* Check for x.all.fbx in root directory. */
+            List<FileInfo> alls = new List<FileInfo>();
+            string rootDir = BaseDirectory + "\\data\\" + path;
+
+            string[] rootFilePaths = Directory.GetFiles(rootDir);
+            foreach (string f in rootFilePaths)
+            {
+                FileInfo fi = new FileInfo(f);
+                if (fi.Name.ToLower().EndsWith(".all.fbx"))
+                {
+                    alls.Add(fi);
+                }
+            }
+
+            /* Convert x.all.fbx */
+            if (alls.Count > 0)
+            {
+                foreach (FileInfo all in alls)
+                {
+                    string outPath = rootDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", ".jms"));
+                    await RunTool(ToolType.Tool, new() { "fbx-to-jms", "all", all.FullName, outPath });
+                }
+            }
+
+            /* Convert render/collision/physics */
+            foreach (ImportTypeInfo importTypeInfo in IMPORT_TYPE_INFOS)
+            {
+                if (importType.HasFlag(importTypeInfo.importType))
+                {
+                    string typeDir = rootDir + "\\" + importTypeInfo.folderName;
+                    if (alls.Count > 0)
+                    {
+                        if (!Directory.Exists(typeDir)) { Directory.CreateDirectory(typeDir); }
+
+                        foreach (FileInfo all in alls)
+                        {
+                            string checkPath = typeDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", ".fbx"));
+                            if (File.Exists(checkPath)) { continue; } // Skip x.all.fbx if there is an x.fbx with same name in the relevant subfolder
+
+                            string inPath = rootDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", "_" + importTypeInfo.folderName + ".jms"));
+                            string outPath = typeDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", ".jms"));
+
+                            File.Copy(inPath, outPath);
+                            File.Delete(inPath);
+                        }
+                    }
+                    if (Directory.Exists(typeDir))
+                    {
+                        List<FileInfo> fbxs = new List<FileInfo>();
+
+                        string[] filePaths = Directory.GetFiles(typeDir);
+                        foreach (string f in filePaths)
+                        {
+                            FileInfo fi = new FileInfo(f);
+                            if (fi.Name.ToLower().EndsWith(".fbx"))
+                            {
+                                fbxs.Add(fi);
+                            }
+                        }
+
+                        foreach (FileInfo fbx in fbxs)
+                        {
+                            string outPath = typeDir + "\\" + (fbx.Name.ToLower().Replace(".fbx", ".jms"));
+                            await RunTool(ToolType.Tool, new() { "fbx-to-jms", importTypeInfo.commandOption, fbx.FullName, outPath });
+                        }
+                    }
+                }
+            }
+
+            /* Convert animations */
+            string animDir = rootDir + "\\animations";
+            if (Directory.Exists(animDir) && importType.HasFlag(ModelCompile.animations))
+            {
+                List<FileInfo> fbxs = new List<FileInfo>();
+
+                string[] filePaths = Directory.GetFiles(animDir);
+                foreach (string f in filePaths)
+                {
+                    FileInfo fi = new FileInfo(f);
+                    if (fi.Name.ToLower().EndsWith(".fbx"))
+                    {
+                        fbxs.Add(fi);
+                    }
+                }
+
+                foreach (FileInfo fbx in fbxs)
+                {
+                    string outPath = animDir + "\\" + (fbx.Name.ToLower().Replace(".fbx", ".jma"));
+                    await RunTool(ToolType.Tool, new() { "fbx-to-jma", fbx.FullName, outPath });
+                }
+            }
+        }
+
         /// <summary>
         /// Import a model
         /// </summary>
         /// <param name="path"></param>
         /// <param name="importType"></param>
         /// <returns></returns>
-        public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression)
+        public override async Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression, bool autoFBX)
         {
             string type = "";
             if (verboseAnim)
@@ -195,6 +324,8 @@ namespace ToolkitLauncher.ToolkitInterface
             {
                 type = "-reset";
             }
+
+            if(autoFBX) { await ModelAutoFBX(path, importType); }
 
             if (importType.HasFlag(ModelCompile.render))
                 if (skyRender)

--- a/Launcher/ToolkitInterface/H3Toolkit.cs
+++ b/Launcher/ToolkitInterface/H3Toolkit.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using ToolkitLauncher.Utility;
 using static ToolkitLauncher.ToolkitProfiles;
 
 namespace ToolkitLauncher.ToolkitInterface
@@ -17,6 +18,16 @@ namespace ToolkitLauncher.ToolkitInterface
         protected string sapienWindowClass
         {
             get => "Sapien";
+        }
+
+        /* For AutoFBX */
+        public override List<ImportTypeInfo> GetImportTypeInfo()
+        {
+            return new List<ImportTypeInfo>() {
+                new ImportTypeInfo(ModelCompile.render, "render", "render"),
+                new ImportTypeInfo(ModelCompile.collision, "collision", "collision"),
+                new ImportTypeInfo(ModelCompile.physics, "physics", "physics")
+            };
         }
 
         override public async Task ImportBitmaps(string path, string type, bool debug_plate)
@@ -33,20 +44,9 @@ namespace ToolkitLauncher.ToolkitInterface
             await RunTool(ToolType.Tool, new() { "strings", path });
         }
 
-        private async Task StructureAutoFBX(string data_file)
-        {
-            /* Convert Structure */
-            string inPath = BaseDirectory + "\\data\\" + data_file.ToLower().Replace(".ass", ".fbx"); // Jank code, should probably make this safer
-            if (File.Exists(inPath))
-            {
-                string outPath = BaseDirectory + "\\data\\" + data_file;
-                await RunTool(ToolType.Tool, new() { "fbx-to-ass", inPath, outPath });
-            }
-        }
-
         override public async Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast, bool autoFBX)
         {
-            if(autoFBX) { await StructureAutoFBX(data_file); }
+            if(autoFBX) { await AutoFBX.Structure(this, data_file, false); }
 
             ToolType tool = useFast ? ToolType.ToolFast : ToolType.Tool;
             string tool_command = structure_command.ToString().Replace("_", "-");
@@ -188,126 +188,6 @@ namespace ToolkitLauncher.ToolkitInterface
 
         }
 
-        // Some nonsense, probably should be an enum actually
-        private class ImportTypeInfo
-        {
-            public ModelCompile importType;
-            public string folderName, commandOption;
-            public ImportTypeInfo(ModelCompile a, string b, string c)
-            {
-                importType = a;
-                folderName = b;
-                commandOption = c;
-            }
-        }
-
-        private static List<ImportTypeInfo> IMPORT_TYPE_INFOS = new List<ImportTypeInfo>()
-        {
-            new ImportTypeInfo(ModelCompile.render, "render", "render"),
-            new ImportTypeInfo(ModelCompile.collision, "collision", "collision"),
-            new ImportTypeInfo(ModelCompile.physics, "physics", "physics")
-        };
-
-        private async Task ModelAutoFBX(string path, ModelCompile importType)
-        {
-            /* Check for x.all.fbx in root directory. */
-            List<FileInfo> alls = new List<FileInfo>();
-            string rootDir = BaseDirectory + "\\data\\" + path;
-
-            string[] rootFilePaths = Directory.GetFiles(rootDir);
-            foreach (string f in rootFilePaths)
-            {
-                FileInfo fi = new FileInfo(f);
-                if (fi.Name.ToLower().EndsWith(".all.fbx"))
-                {
-                    alls.Add(fi);
-                }
-            }
-
-            /* Convert x.all.fbx */
-            if (alls.Count > 0)
-            {
-                foreach (FileInfo all in alls)
-                {
-                    string outPath = rootDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", ".jms"));
-                    await RunTool(ToolType.Tool, new() { "fbx-to-jms", "all", all.FullName, outPath });
-                }
-            }
-
-            /* Convert render/collision/physics */
-            foreach (ImportTypeInfo importTypeInfo in IMPORT_TYPE_INFOS)
-            {
-                if (importType.HasFlag(importTypeInfo.importType))
-                {
-                    string typeDir = rootDir + "\\" + importTypeInfo.folderName;
-
-                    /* Copy x.all.fbx output if it exists */
-                    if (alls.Count > 0)
-                    {
-                        if (!Directory.Exists(typeDir)) { Directory.CreateDirectory(typeDir); }
-
-                        foreach (FileInfo all in alls)
-                        {
-                            string inPath = rootDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", "_" + importTypeInfo.folderName + ".jms"));
-                            string outPath = typeDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", ".jms"));
-
-                            string checkPath = typeDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", ".fbx"));
-                            if (File.Exists(checkPath)) { File.Delete(inPath); continue; } // Skip x.all.fbx if there is an x.fbx with same name in the relevant subfolder
-
-                            if(File.Exists(outPath)) { File.Delete(outPath); }
-
-                            File.Copy(inPath, outPath);
-                            File.Delete(inPath);
-                        }
-                    }
-                    /* Convert fbx in relevant sub folders */
-                    if (Directory.Exists(typeDir))
-                    {
-                        List<FileInfo> fbxs = new List<FileInfo>();
-
-                        string[] filePaths = Directory.GetFiles(typeDir);
-                        foreach (string f in filePaths)
-                        {
-                            FileInfo fi = new FileInfo(f);
-                            if (fi.Name.ToLower().EndsWith(".fbx"))
-                            {
-                                fbxs.Add(fi);
-                            }
-                        }
-
-                        foreach (FileInfo fbx in fbxs)
-                        {
-                            string outPath = typeDir + "\\" + (fbx.Name.ToLower().Replace(".fbx", ".jms"));
-                            await RunTool(ToolType.Tool, new() { "fbx-to-jms", importTypeInfo.commandOption, fbx.FullName, outPath });
-                        }
-                    }
-                }
-            }
-
-            /* Convert animations */
-            string animDir = rootDir + "\\animations";
-            if (Directory.Exists(animDir) && importType.HasFlag(ModelCompile.animations))
-            {
-                List<FileInfo> fbxs = new List<FileInfo>();
-
-                string[] filePaths = Directory.GetFiles(animDir);
-                foreach (string f in filePaths)
-                {
-                    FileInfo fi = new FileInfo(f);
-                    if (fi.Name.ToLower().EndsWith(".fbx"))
-                    {
-                        fbxs.Add(fi);
-                    }
-                }
-
-                foreach (FileInfo fbx in fbxs)
-                {
-                    string outPath = animDir + "\\" + (fbx.Name.ToLower().Replace(".fbx", ".jma"));
-                    await RunTool(ToolType.Tool, new() { "fbx-to-jma", fbx.FullName, outPath });
-                }
-            }
-        }
-
         /// <summary>
         /// Import a model
         /// </summary>
@@ -330,7 +210,7 @@ namespace ToolkitLauncher.ToolkitInterface
                 type = "-reset";
             }
 
-            if(autoFBX) { await ModelAutoFBX(path, importType); }
+            if(autoFBX) { await AutoFBX.Model(this, path, importType); }
 
             if (importType.HasFlag(ModelCompile.render))
                 if (skyRender)

--- a/Launcher/ToolkitInterface/H3Toolkit.cs
+++ b/Launcher/ToolkitInterface/H3Toolkit.cs
@@ -210,7 +210,7 @@ namespace ToolkitLauncher.ToolkitInterface
                 type = "-reset";
             }
 
-            if(autoFBX) { await AutoFBX.Model(this, path, importType); }
+            if(autoFBX) { await AutoFBX.Model(this, path, importType, false); }
 
             if (importType.HasFlag(ModelCompile.render))
                 if (skyRender)

--- a/Launcher/ToolkitInterface/H3Toolkit.cs
+++ b/Launcher/ToolkitInterface/H3Toolkit.cs
@@ -188,7 +188,7 @@ namespace ToolkitLauncher.ToolkitInterface
 
         }
 
-        // Some nonsense
+        // Some nonsense, probably should be an enum actually
         private class ImportTypeInfo
         {
             public ModelCompile importType;
@@ -205,7 +205,7 @@ namespace ToolkitLauncher.ToolkitInterface
         {
             new ImportTypeInfo(ModelCompile.render, "render", "render"),
             new ImportTypeInfo(ModelCompile.collision, "collision", "collision"),
-            new ImportTypeInfo(ModelCompile.physics, "physics", "physics-or-all")
+            new ImportTypeInfo(ModelCompile.physics, "physics", "physics")
         };
 
         private async Task ModelAutoFBX(string path, ModelCompile importType)
@@ -240,22 +240,27 @@ namespace ToolkitLauncher.ToolkitInterface
                 if (importType.HasFlag(importTypeInfo.importType))
                 {
                     string typeDir = rootDir + "\\" + importTypeInfo.folderName;
+
+                    /* Copy x.all.fbx output if it exists */
                     if (alls.Count > 0)
                     {
                         if (!Directory.Exists(typeDir)) { Directory.CreateDirectory(typeDir); }
 
                         foreach (FileInfo all in alls)
                         {
-                            string checkPath = typeDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", ".fbx"));
-                            if (File.Exists(checkPath)) { continue; } // Skip x.all.fbx if there is an x.fbx with same name in the relevant subfolder
-
                             string inPath = rootDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", "_" + importTypeInfo.folderName + ".jms"));
                             string outPath = typeDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", ".jms"));
+
+                            string checkPath = typeDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", ".fbx"));
+                            if (File.Exists(checkPath)) { File.Delete(inPath); continue; } // Skip x.all.fbx if there is an x.fbx with same name in the relevant subfolder
+
+                            if(File.Exists(outPath)) { File.Delete(outPath); }
 
                             File.Copy(inPath, outPath);
                             File.Delete(inPath);
                         }
                     }
+                    /* Convert fbx in relevant sub folders */
                     if (Directory.Exists(typeDir))
                     {
                         List<FileInfo> fbxs = new List<FileInfo>();

--- a/Launcher/ToolkitInterface/ToolkitBase.cs
+++ b/Launcher/ToolkitInterface/ToolkitBase.cs
@@ -149,8 +149,9 @@ namespace ToolkitLauncher.ToolkitInterface
         /// <param name="release">H2V: An unused bool. Always set to true</param>
         /// <param name="useFast">H2-H3: Run a play build of tool if the toolset has one</param>
         /// <param name="phantom_fix">CE: Whatever to apply the phantom fix</param>
+        /// <param name="autoFBX"></param>
         /// <returns></returns>
-        public abstract Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast);
+        public abstract Task ImportStructure(StructureType structure_command, string data_file, bool phantom_fix, bool release, bool useFast, bool autoFBX);
 
         /// <summary>
         /// Import geometry to generate various types of model related tags
@@ -166,8 +167,9 @@ namespace ToolkitLauncher.ToolkitInterface
         /// <param name="uncompressedAnim"></param>
         /// <param name="skyRender"></param>
         /// <param name="resetCompression"></param>
+        /// <param name="autoFBX"></param>
         /// <returns></returns>
-        public abstract Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression);
+        public abstract Task ImportModel(string path, ModelCompile importType, bool phantomFix, bool h2SelectionLogic, bool renderPRT, bool FPAnim, string characterFPPath, string weaponFPPath, bool accurateRender, bool verboseAnim, bool uncompressedAnim, bool skyRender, bool resetCompression, bool autoFBX);
 
         /// <summary>
         /// Import a WAV file to generate a sound tag

--- a/Launcher/ToolkitInterface/ToolkitBase.cs
+++ b/Launcher/ToolkitInterface/ToolkitBase.cs
@@ -89,6 +89,16 @@ namespace ToolkitLauncher.ToolkitInterface
             int instanceCount,
             bool instanceOutput);
 
+        /* For AutoFBX */
+        public record ImportTypeInfo(
+            ModelCompile importType,
+            string folderName,
+            string commandOption
+        );
+
+        /* For AutoFBX */
+        public abstract List<ImportTypeInfo> GetImportTypeInfo();
+
         /// <summary>
         /// Build a lightmap for a given scenario and BSP
         /// </summary>

--- a/Launcher/ToolkitLauncher.csproj
+++ b/Launcher/ToolkitLauncher.csproj
@@ -64,6 +64,7 @@
     <EmbeddedResource Include="Documentation.json" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FbxParser" Version="2.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.216">
@@ -74,6 +75,7 @@
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Management" Version="5.0.0" />
     <PackageReference Include="TlshSharp" Version="1.0.0" />
+    <PackageReference Include="UkooLabs.FbxSharpie" Version="1.0.99" />
     <PackageReference Include="WindowsAPICodePack-Shell">
       <Version>1.1.1</Version>
     </PackageReference>

--- a/Launcher/ToolkitLauncher.csproj
+++ b/Launcher/ToolkitLauncher.csproj
@@ -64,7 +64,6 @@
     <EmbeddedResource Include="Documentation.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FbxParser" Version="2.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.216">

--- a/Launcher/Utility/AutoFBX.cs
+++ b/Launcher/Utility/AutoFBX.cs
@@ -141,7 +141,7 @@ namespace ToolkitLauncher.Utility
         {
             FbxDocument fbx = FbxIO.Read(path);
 
-            string FuckYou(UkooLabs.FbxSharpie.Tokens.Token token)
+            string GetTokenValueAsString(UkooLabs.FbxSharpie.Tokens.Token token)
             {
                 if(token is UkooLabs.FbxSharpie.Tokens.StringToken)
                 {
@@ -158,7 +158,7 @@ namespace ToolkitLauncher.Utility
                 return "{value}";
             }
 
-            long FuckYou2(UkooLabs.FbxSharpie.Tokens.Token token)
+            long GetTokenValueAsLong(UkooLabs.FbxSharpie.Tokens.Token token)
             {
                 if (token is UkooLabs.FbxSharpie.Tokens.Value.IntegerToken)
                 {
@@ -171,7 +171,7 @@ namespace ToolkitLauncher.Utility
                 return 0;
             }
 
-            FbxNode GetFuckYou(FbxDocument f, string identifier)
+            FbxNode GetNodeByIdentifierValue(FbxDocument f, string identifier)
             {
                 foreach (FbxNode n in f.Nodes)
                 {
@@ -186,12 +186,12 @@ namespace ToolkitLauncher.Utility
             /* Step #1 - Search "Objects" for any Models with a name starting with '@' or '$' and then grab the id values for it */
             List<FbxNode> StNodes5a = new List<FbxNode>();
             List<long> ModelIDs = new List<long>();
-            foreach(FbxNode node in GetFuckYou(fbx, "Objects").Nodes)
+            foreach(FbxNode node in GetNodeByIdentifierValue(fbx, "Objects").Nodes)
             {
                 if(node != null && node.Properties != null && node.Properties.Length > 2)
                 {
-                    string name = FuckYou(node.Properties[1]);
-                    long id = FuckYou2(node.Properties[0]);
+                    string name = GetTokenValueAsString(node.Properties[1]);
+                    long id = GetTokenValueAsLong(node.Properties[0]);
                     if (name.StartsWith("Model::@") || name.StartsWith("Model::$"))
                     {
                         ModelIDs.Add(id);
@@ -204,12 +204,12 @@ namespace ToolkitLauncher.Utility
             /* Step #2 - Search "Connections" for any entries containing the any ModelIDs we collected in property slot #2, store the value from slot #1 as that is the child id for the mesh */
             List<FbxNode> StNodes6a = new List<FbxNode>();
             List<long> MeshIDs = new List<long>();
-            foreach (FbxNode node in GetFuckYou(fbx, "Connections").Nodes)
+            foreach (FbxNode node in GetNodeByIdentifierValue(fbx, "Connections").Nodes)
             {
                 if (node != null && node.Properties != null && node.Properties.Length > 2)
                 {
-                    long id1 = FuckYou2(node.Properties[1]);
-                    long id2 = FuckYou2(node.Properties[2]);
+                    long id1 = GetTokenValueAsLong(node.Properties[1]);
+                    long id2 = GetTokenValueAsLong(node.Properties[2]);
                     if (ModelIDs.Contains(id2))
                     {
                         MeshIDs.Add(id1);
@@ -225,9 +225,9 @@ namespace ToolkitLauncher.Utility
             {
                 if (node != null && node.Properties != null && node.Properties.Length > 2)
                 {
-                    long id = FuckYou2(node.Properties[0]);
-                    string slot1 = FuckYou(node.Properties[1]);
-                    string slot2 = FuckYou(node.Properties[2]);
+                    long id = GetTokenValueAsLong(node.Properties[0]);
+                    string slot1 = GetTokenValueAsString(node.Properties[1]);
+                    string slot2 = GetTokenValueAsString(node.Properties[2]);
                     if (slot1.ToLower().Contains("geometry") && slot2.ToLower().Contains("mesh") && MeshIDs.Contains(id))
                     {
                         continue;

--- a/Launcher/Utility/AutoFBX.cs
+++ b/Launcher/Utility/AutoFBX.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ToolkitLauncher.ToolkitInterface;
+
+namespace ToolkitLauncher.Utility
+{
+    class AutoFBX
+    {
+
+        public static async Task Structure(ToolkitBase tk, string filePath, Boolean isJMS)
+        {
+            /* Convert Structure */
+            string inPath = tk.GetDataDirectory() + "\\" + filePath.ToLower().Replace(isJMS?".jms":".ass", ".fbx"); // Jank code, should probably make this safer
+            if (File.Exists(inPath))
+            {
+                string outPath = tk.GetDataDirectory() + "\\" + filePath;
+                await tk.RunTool(ToolType.Tool, new() { "fbx-to-ass", inPath, outPath });
+            }
+        }
+
+        public static async Task Model(ToolkitBase tk, string path, ModelCompile importType)
+        {
+            /* Check for x.all.fbx in root directory. */
+            List<FileInfo> alls = new List<FileInfo>();
+            string rootDir = tk.GetDataDirectory() + "\\" + path;
+
+            string[] rootFilePaths = Directory.GetFiles(rootDir, "*.all.fbx");
+            foreach (string f in rootFilePaths)
+            {
+                FileInfo fi = new FileInfo(f);
+                alls.Add(fi);
+            }
+
+            /* Convert x.all.fbx */
+            foreach (FileInfo all in alls)
+            {
+                string outPath = rootDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", ".jms"));
+                await tk.RunTool(ToolType.Tool, new() { "fbx-to-jms", "all", all.FullName, outPath });
+            }
+
+            /* Convert render/collision/physics */
+            foreach (ToolkitBase.ImportTypeInfo importTypeInfo in tk.GetImportTypeInfo())
+            {
+                if (importType.HasFlag(importTypeInfo.importType))
+                {
+                    string typeDir = rootDir + "\\" + importTypeInfo.folderName;
+
+                    /* Copy x.all.fbx output if it exists */
+                    if (alls.Count > 0)
+                    {
+                        if (!Directory.Exists(typeDir)) { Directory.CreateDirectory(typeDir); }
+
+                        foreach (FileInfo all in alls)
+                        {
+                            string inPath = rootDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", "_" + importTypeInfo.folderName + ".jms")); // Lowercase enforce to avoid .FBX <-> .fbx mismatches
+                            string outPath = typeDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", ".jms"));
+
+                            string checkPath = typeDir + "\\" + (all.Name.ToLower().Replace(".all.fbx", ".fbx"));
+                            if (File.Exists(checkPath)) { continue; } // Skip x.all.fbx if there is an x.fbx with same name in the relevant subfolder
+
+                            if (File.Exists(outPath)) { File.Delete(outPath); }
+
+                            File.Move(inPath, outPath);
+                        }
+                    }
+                    /* Convert fbx in relevant sub folders */
+                    if (Directory.Exists(typeDir))
+                    {
+                        List<FileInfo> fbxs = new List<FileInfo>();
+
+                        string[] filePaths = Directory.GetFiles(typeDir, "*.fbx");
+                        foreach (string f in filePaths)
+                        {
+                            FileInfo fi = new FileInfo(f);
+                            fbxs.Add(fi);
+                        }
+
+                        foreach (FileInfo fbx in fbxs)
+                        {
+                            string outPath = typeDir + "\\" + (fbx.Name.ToLower().Replace(".fbx", ".jms")); // Lowercase enforce to avoid .FBX <-> .fbx mismatches
+                            await tk.RunTool(ToolType.Tool, new() { "fbx-to-jms", importTypeInfo.commandOption, fbx.FullName, outPath });
+                        }
+                    }
+                }
+            }
+
+            /* Delete any unused .jms files in root directory converted by 'all' */
+            foreach (FileInfo all in alls)
+            {
+                foreach (ToolkitBase.ImportTypeInfo importTypeInfo in tk.GetImportTypeInfo())
+                {
+                    string fp = rootDir + "\\" + all.Name.ToLower().Replace(".all.fbx", "_" + importTypeInfo.folderName + ".jms"); // Lowercase enforce to avoid .FBX <-> .fbx mismatches
+                    if (File.Exists(fp)) { File.Delete(fp); }
+                }
+            }
+
+            /* Convert animations */
+            string animDir = rootDir + "\\animations";
+            if (Directory.Exists(animDir) && importType.HasFlag(ModelCompile.animations))
+            {
+                List<FileInfo> fbxs = new List<FileInfo>();
+
+                string[] filePaths = Directory.GetFiles(animDir, "*.fbx");
+                foreach (string f in filePaths)
+                {
+                    FileInfo fi = new FileInfo(f);
+                    fbxs.Add(fi);
+                }
+
+                foreach (FileInfo fbx in fbxs)
+                {
+                    string outPath = animDir + "\\" + (fbx.Name.ToLower().Replace(".fbx", ".jma")); // Lowercase enforce to avoid .FBX <-> .fbx mismatches
+                    await tk.RunTool(ToolType.Tool, new() { "fbx-to-jma", fbx.FullName, outPath });
+                }
+            }
+        }
+    }
+}

--- a/ToolkitLauncher.sln
+++ b/ToolkitLauncher.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30503.244
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ToolkitLauncher", "Launcher\ToolkitLauncher.csproj", "{EE9D5075-A31E-4393-BD62-59A3AD5C3FC5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ToolkitLauncher", "Launcher\ToolkitLauncher.csproj", "{EE9D5075-A31E-4393-BD62-59A3AD5C3FC5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Automatically finds and converts FBX files to JMS or ASS when you run commands like collision, physics, or structure.
Also, if you place an fbx file in the root of a directory with the extension ".all.fbx" it will be used for render, collision, and physics.
EX: "data/objects/vehicles/test/test.fbx.all" 
This should make the workflow a lot smoother.

Let me know if I should adjust anything. A bit messy.

Adding support for H1/H2 should be a real easy copy paste job but I need to know the folder structure and commands for each game.