### PR TITLE
Address issues #32 and #22

### DIFF
--- a/Launcher/CancelableProgressBarWindow.xaml.cs
+++ b/Launcher/CancelableProgressBarWindow.xaml.cs
@@ -103,10 +103,12 @@ namespace ToolkitLauncher
                 progress.IsIndeterminate = true;
             } else if (Complete)
             {
+                stopwatch.Stop();
+                string timeElapsed = String.Format("Time elapsed: {0:00}:{1:00}:{2:00}", stopwatch.Elapsed.Hours, stopwatch.Elapsed.Minutes, stopwatch.Elapsed.Seconds);
                 if (IsCancelled)
-                    Status = cancelReason is null ? "Canceled!" : $"Canceled ({cancelReason})!";
+                    Status = cancelReason is null ? "Canceled! " + timeElapsed : $"Canceled ({cancelReason})! " + timeElapsed;
                 else
-                    Status = "Done!";
+                    Status = "Done! " + timeElapsed;
                 progress.IsIndeterminate = false;
                 progress.Value = progress.Maximum;
             }
@@ -164,6 +166,8 @@ namespace ToolkitLauncher
             else
                 Cancel();
         }
+
+        private Stopwatch stopwatch = Stopwatch.StartNew();
     }
 
     /// <summary>

--- a/Launcher/CancelableProgressBarWindow.xaml.cs
+++ b/Launcher/CancelableProgressBarWindow.xaml.cs
@@ -104,7 +104,7 @@ namespace ToolkitLauncher
             } else if (Complete)
             {
                 stopwatch.Stop();
-                string timeElapsed = String.Format("Time elapsed: {0:00}:{1:00}:{2:00}", stopwatch.Elapsed.Hours, stopwatch.Elapsed.Minutes, stopwatch.Elapsed.Seconds);
+                string timeElapsed = String.Format("({0:00}:{1:00})", stopwatch.Elapsed.Hours, stopwatch.Elapsed.Minutes);
                 if (IsCancelled)
                     Status = cancelReason is null ? "Canceled! " + timeElapsed : $"Canceled ({cancelReason})! " + timeElapsed;
                 else

--- a/Launcher/FilePicker.cs
+++ b/Launcher/FilePicker.cs
@@ -97,7 +97,10 @@ public class FilePicker
     {
 		string? local_path = ConvertFSPathToLocalPath(path, options.pathRoot);
 		if (local_path is null)
+        {
+			MessageBox.Show("File path was not within the current toolkit directory", "Error!");
 			return false;
+		}
 		if (options.strip_extension)
 			local_path = local_path.Substring(0, local_path.Length - Path.GetExtension(local_path).Length);
 		if (options.parent)


### PR DESCRIPTION
Did not include toolkit switching when the path is incorrect for #32 and for #22 the time elapsed is only displayed when the lightmap is cancelled or finished.