### PR TITLE
Fixed missing brackets in standard ImportModel function for H2/H3/ODS…

### DIFF
--- a/Launcher/ToolkitInterface/H2AToolkit.cs
+++ b/Launcher/ToolkitInterface/H2AToolkit.cs
@@ -108,9 +108,11 @@ namespace ToolkitLauncher.ToolkitInterface
             if (autoFBX) { await AutoFBX.Model(this, path, importType); }
 
             if (importType.HasFlag(ModelCompile.render))
+            {
                 // Generate shaders if requested
                 if (genShaders) { if (!AutoShaders.CreateEmptyShaders(BaseDirectory, path, "H2")) { return; }; }
                 await RunTool(ToolType.Tool, new() { "render", path, accurateRender.ToString(), renderPRT.ToString() });
+            }
             if (importType.HasFlag(ModelCompile.collision))
                 await RunTool(ToolType.Tool, new() { "collision", path });
             if (importType.HasFlag(ModelCompile.physics))

--- a/Launcher/ToolkitInterface/H3ODSTToolkit.cs
+++ b/Launcher/ToolkitInterface/H3ODSTToolkit.cs
@@ -40,6 +40,7 @@ namespace ToolkitLauncher.ToolkitInterface
             if (autoFBX) { await AutoFBX.Model(this, path, importType); }
 
             if (importType.HasFlag(ModelCompile.render))
+            {
                 // Generate shaders if requested
                 if (genShaders) { if (!AutoShaders.CreateEmptyShaders(BaseDirectory, path, "H3ODST")) { return; }; }
                 if (skyRender)
@@ -50,6 +51,7 @@ namespace ToolkitLauncher.ToolkitInterface
                     await RunTool(ToolType.Tool, new() { "render-pda", path });
                 else
                     await RunTool(ToolType.Tool, new() { "render", path, renderPRT ? "final" : "draft" });
+            }
             if (importType.HasFlag(ModelCompile.collision))
                 await RunTool(ToolType.Tool, new() { "collision", path });
             if (importType.HasFlag(ModelCompile.physics))

--- a/Launcher/ToolkitInterface/H3Toolkit.cs
+++ b/Launcher/ToolkitInterface/H3Toolkit.cs
@@ -204,6 +204,7 @@ namespace ToolkitLauncher.ToolkitInterface
             if (autoFBX) { await AutoFBX.Model(this, path, importType); }
 
             if (importType.HasFlag(ModelCompile.render))
+            {
                 // Generate shaders if requested
                 if (genShaders) { if (!AutoShaders.CreateEmptyShaders(BaseDirectory, path, "H3")) { return; }; }
                 if (skyRender)
@@ -212,6 +213,7 @@ namespace ToolkitLauncher.ToolkitInterface
                     await RunTool(ToolType.Tool, new() { "render-accurate", path, renderPRT ? "final" : "draft" });
                 else
                     await RunTool(ToolType.Tool, new() { "render", path, renderPRT ? "final" : "draft" });
+            }
             if (importType.HasFlag(ModelCompile.collision))
                 await RunTool(ToolType.Tool, new() { "collision", path });
             if (importType.HasFlag(ModelCompile.physics))


### PR DESCRIPTION
…T causing erroneous render model imports during other model type (physics, collision) compilation.

Small bug fix.