### PR TITLE
Fixes for lightmapper issues in Reach

### DIFF
--- a/Launcher/Documentation.json
+++ b/Launcher/Documentation.json
@@ -37,6 +37,16 @@
     "H3": {
       "Packaging": "h3/tools/h3-ek/h3-tool/#build-cache-file",
       "Lighting": "h3/tools/h3-ek/h3-tool/#baking-lightmaps-faux"
+    },
+    "HR": {
+      "Packaging": "hr/hr-ek/hr-tool/#build-cache-file-cache",
+      "Lighting": "hr/hr-ek/hr-tool/#baking-lightmaps-faux"
+    },
+    "H4": {
+
+    },
+    "H2A": {
+      "Base": "H4"
     }
   }
 }

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -974,7 +974,7 @@ namespace ToolkitLauncher
             // tool doesn't support a value of 0 or 1, the bounds are [0, 1], so we adjust the value a bit to get something reasonable
             float light_level_slider = (float)Math.Max(Math.Min(light_quality_slider.ConvertedValue, 0.999999), 0.000001);
             int instance_count = 1;
-            if (!halo_ce && !halo_2_standalone_stock && !halo_reach && !halo_4)
+            if (!halo_ce && !halo_2_standalone_stock && !halo_4)
             {
                 if (instance_value.Text.Length == 0 ? true : Int32.TryParse(instance_value.Text, out instance_count))
                 {
@@ -1034,7 +1034,7 @@ namespace ToolkitLauncher
                 var info = ToolkitBase.SplitStructureFilename(level_path, bsp_path, Path.GetDirectoryName(toolkit_profile.ToolPath));
                 var scen_path = Path.Combine(info.ScenarioPath, info.ScenarioName);
                 CancelableProgressBarWindow<int> progress = null;
-                if (!halo_ce && !halo_2_standalone_stock && !halo_reach && !halo_4 && lightmaps_args.instanceCount > 1 || !halo_ce && !halo_2 && !halo_reach && !halo_4)
+                if (lightmaps_args.instanceCount > 1 || halo_3 || halo_reach)
                 {
                     progress = new CancelableProgressBarWindow<int>();
                     progress.Owner = this;

--- a/Launcher/ToolkitInterface/H3Toolkit.cs
+++ b/Launcher/ToolkitInterface/H3Toolkit.cs
@@ -75,7 +75,7 @@ namespace ToolkitLauncher.ToolkitInterface
             MergeFail
         };
 
-        public async Task FauxLocalFarm(string scenario, string bsp, string lightmapGroup, string quality, int clientCount, bool useFast, bool instanceOutput, ICancellableProgress<int> progress)
+        public virtual async Task FauxLocalFarm(string scenario, string bsp, string lightmapGroup, string quality, int clientCount, bool useFast, bool instanceOutput, ICancellableProgress<int> progress)
         {
             progress.MaxValue += 1 + 1 + 5 * (clientCount + 1) + 1 + 3;
 

--- a/Launcher/ToolkitInterface/HRToolkit.cs
+++ b/Launcher/ToolkitInterface/HRToolkit.cs
@@ -51,7 +51,7 @@ namespace ToolkitLauncher.ToolkitInterface
             await RunTool(tool, args, true);
         }
 
-        public new async Task FauxLocalFarm(string scenario, string bsp, string lightmapGroup, string quality, int clientCount, bool useFast, bool instanceOutput, ICancellableProgress<int> progress)
+        override public async Task FauxLocalFarm(string scenario, string bsp, string lightmapGroup, string quality, int clientCount, bool useFast, bool instanceOutput, ICancellableProgress<int> progress)
         {
             progress.MaxValue += 1 + 1 + 5 * (clientCount + 1) + 1 + 3;
 


### PR DESCRIPTION
Make sure the Reach FauxLocalFarm function overrides the H3 function

Ensure progress variable is always defined for H3 and Reach

Fix docs for Reach+