### PR TITLE
Fixed broken H3 ALL model import option

### DIFF
--- a/Launcher/ToolkitInterface/H3Toolkit.cs
+++ b/Launcher/ToolkitInterface/H3Toolkit.cs
@@ -184,8 +184,8 @@ namespace ToolkitLauncher.ToolkitInterface
             if (importType.HasFlag(ModelCompile.all))
             {
                 await RunTool(ToolType.Tool, ImportRender(genShaders, skyRender, BaseDirectory, path, accurateRender, renderPRT), true);
-                await RunTool(ToolType.Tool, ImportCollision(path), true);
-                await RunTool(ToolType.Tool, ImportPhysics(path), true);
+                await RunTool(ToolType.Tool, new List<string> { "collision", path }, true);
+                await RunTool(ToolType.Tool, new List<string> { "collision", path }, true);
                 await RunTool(ToolType.Tool, ImportAnimations(FPAnim, verboseAnim, uncompressedAnim, resetCompression, path, characterFPPath, weaponFPPath), true);
                 return;
             }
@@ -195,11 +195,11 @@ namespace ToolkitLauncher.ToolkitInterface
             }
             else if (importType.HasFlag(ModelCompile.collision))
             {
-                await RunTool(ToolType.Tool, ImportCollision(path), true);
+                await RunTool(ToolType.Tool, new List<string> { "collision", path }, true);
             }
             else if (importType.HasFlag(ModelCompile.physics))
             {
-                await RunTool(ToolType.Tool, ImportPhysics(path), true);
+                await RunTool(ToolType.Tool, new List<string> { "collision", path }, true);
             }
             else if (importType.HasFlag(ModelCompile.animations))
             {
@@ -230,26 +230,6 @@ namespace ToolkitLauncher.ToolkitInterface
                 args.Add(path);
                 args.Add(renderPRT ? "final" : "draft");
             }
-
-            return args;
-        }
-
-        public static List<string> ImportCollision(string path)
-        {
-            List<string> args = new List<string>();
-
-            args.Add("collision");
-            args.Add(path);
-
-            return args;
-        }
-
-        public static List<string> ImportPhysics(string path)
-        {
-            List<string> args = new List<string>();
-
-            args.Add("physics");
-            args.Add(path);
 
             return args;
         }

--- a/Launcher/ToolkitInterface/H3Toolkit.cs
+++ b/Launcher/ToolkitInterface/H3Toolkit.cs
@@ -189,20 +189,19 @@ namespace ToolkitLauncher.ToolkitInterface
                 await RunTool(ToolType.Tool, ImportAnimations(FPAnim, verboseAnim, uncompressedAnim, resetCompression, path, characterFPPath, weaponFPPath), true);
                 return;
             }
-
-            if (importType.HasFlag(ModelCompile.render))
+            else if (importType.HasFlag(ModelCompile.render))
             {
                 await RunTool(ToolType.Tool, ImportRender(genShaders, skyRender, BaseDirectory, path, accurateRender, renderPRT), true);
             }
-            if (importType.HasFlag(ModelCompile.collision))
+            else if (importType.HasFlag(ModelCompile.collision))
             {
                 await RunTool(ToolType.Tool, ImportCollision(path), true);
             }
-            if (importType.HasFlag(ModelCompile.physics))
+            else if (importType.HasFlag(ModelCompile.physics))
             {
                 await RunTool(ToolType.Tool, ImportPhysics(path), true);
             }
-            if (importType.HasFlag(ModelCompile.animations))
+            else if (importType.HasFlag(ModelCompile.animations))
             {
                 await RunTool(ToolType.Tool, ImportAnimations(FPAnim, verboseAnim, uncompressedAnim, resetCompression, path, characterFPPath, weaponFPPath), true);
             }

--- a/Launcher/ToolkitInterface/H3Toolkit.cs
+++ b/Launcher/ToolkitInterface/H3Toolkit.cs
@@ -181,27 +181,19 @@ namespace ToolkitLauncher.ToolkitInterface
         {
             if (autoFBX) { await AutoFBX.Model(this, path, importType); }
 
-            if (importType.HasFlag(ModelCompile.all))
-            {
-                await RunTool(ToolType.Tool, ImportRender(genShaders, skyRender, BaseDirectory, path, accurateRender, renderPRT), true);
-                await RunTool(ToolType.Tool, new List<string> { "collision", path }, true);
-                await RunTool(ToolType.Tool, new List<string> { "collision", path }, true);
-                await RunTool(ToolType.Tool, ImportAnimations(FPAnim, verboseAnim, uncompressedAnim, resetCompression, path, characterFPPath, weaponFPPath), true);
-                return;
-            }
-            else if (importType.HasFlag(ModelCompile.render))
+            if (importType.HasFlag(ModelCompile.render))
             {
                 await RunTool(ToolType.Tool, ImportRender(genShaders, skyRender, BaseDirectory, path, accurateRender, renderPRT), true);
             }
-            else if (importType.HasFlag(ModelCompile.collision))
+            if (importType.HasFlag(ModelCompile.collision))
             {
                 await RunTool(ToolType.Tool, new List<string> { "collision", path }, true);
             }
-            else if (importType.HasFlag(ModelCompile.physics))
+            if (importType.HasFlag(ModelCompile.physics))
             {
                 await RunTool(ToolType.Tool, new List<string> { "collision", path }, true);
             }
-            else if (importType.HasFlag(ModelCompile.animations))
+            if (importType.HasFlag(ModelCompile.animations))
             {
                 await RunTool(ToolType.Tool, ImportAnimations(FPAnim, verboseAnim, uncompressedAnim, resetCompression, path, characterFPPath, weaponFPPath), true);
             }

--- a/Launcher/ToolkitInterface/H3Toolkit.cs
+++ b/Launcher/ToolkitInterface/H3Toolkit.cs
@@ -181,44 +181,31 @@ namespace ToolkitLauncher.ToolkitInterface
         {
             if (autoFBX) { await AutoFBX.Model(this, path, importType); }
 
-            List<string> args = new List<string>();
-
-            // Check if import type is "all"
-            if (importType.HasFlag(ModelCompile.render) && importType.HasFlag(ModelCompile.collision) && importType.HasFlag(ModelCompile.physics) && importType.HasFlag(ModelCompile.animations))
+            if (importType.HasFlag(ModelCompile.all))
             {
-                args = ImportRender(genShaders, skyRender, BaseDirectory, path, accurateRender, renderPRT);
-                await RunTool(ToolType.Tool, args, true);
-                args.Clear();
-                args = ImportCollision(path);
-                await RunTool(ToolType.Tool, args, true);
-                args.Clear();
-                args = ImportPhysics(path);
-                await RunTool(ToolType.Tool, args, true);
-                args.Clear();
-                args = ImportAnimations(FPAnim, verboseAnim, uncompressedAnim, resetCompression, path, characterFPPath, weaponFPPath);
-                await RunTool(ToolType.Tool, args, true);
-
+                await RunTool(ToolType.Tool, ImportRender(genShaders, skyRender, BaseDirectory, path, accurateRender, renderPRT), true);
+                await RunTool(ToolType.Tool, ImportCollision(path), true);
+                await RunTool(ToolType.Tool, ImportPhysics(path), true);
+                await RunTool(ToolType.Tool, ImportAnimations(FPAnim, verboseAnim, uncompressedAnim, resetCompression, path, characterFPPath, weaponFPPath), true);
                 return;
             }
 
             if (importType.HasFlag(ModelCompile.render))
             {
-                args = ImportRender(genShaders, skyRender, BaseDirectory, path, accurateRender, renderPRT);
+                await RunTool(ToolType.Tool, ImportRender(genShaders, skyRender, BaseDirectory, path, accurateRender, renderPRT), true);
             }
             if (importType.HasFlag(ModelCompile.collision))
             {
-                args = ImportCollision(path);
+                await RunTool(ToolType.Tool, ImportCollision(path), true);
             }
             if (importType.HasFlag(ModelCompile.physics))
             {
-                args = ImportPhysics(path);
+                await RunTool(ToolType.Tool, ImportPhysics(path), true);
             }
             if (importType.HasFlag(ModelCompile.animations))
             {
-                args = ImportAnimations(FPAnim, verboseAnim, uncompressedAnim, resetCompression, path, characterFPPath, weaponFPPath);
+                await RunTool(ToolType.Tool, ImportAnimations(FPAnim, verboseAnim, uncompressedAnim, resetCompression, path, characterFPPath, weaponFPPath), true);
             }
-
-            await RunTool(ToolType.Tool, args, true);
         }
 
         public static List<string> ImportRender(bool genShaders, bool skyRender, string BaseDirectory, string path, bool accurateRender, bool renderPRT)


### PR DESCRIPTION
Noticed that using the "all" option for model imports in H3 has been broken since [this commit](https://github.com/num0005/Osoyoos-Launcher/commit/9c38ee2b5924c7fcf0fc6526a823fdd989bf698f#diff-14149d47a4393e090ee06a15610f4a6f7e01256cc67c9e137ee7d0e253d810d5) (H3Toolkit.cs, line 181-244) by General, when he refactored the model import types section it failed to account for multiple options and would try passing all the separate tool commands as a single argument.

This is a fairly straightforward fix for this, I simply added a check for "all" being selected and then run each command one by one as it used to. I also slightly refactored the section into separate functions to avoid code repetition.